### PR TITLE
feat(message-arguments): improved argument type values

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ type Args1 = ICUMessageArguments<`{theme, select,
   dark {The interface will be dark}
   other {The interface will use default colors}
 }`>;
-// Result: { theme: 'light' | 'dark' | ({} & string) | ({} & number) | boolean | undefined | null }
+// Result: { theme: 'light' | 'dark' | ({} & string) | ({} & number) | boolean | null }
 
 // Extract tag names
 type Tags = ICUMessageTags<'Click <link>here</link> to continue'>;
@@ -50,21 +50,21 @@ Extracts the argument types from an ICU message string.
 
 #### Message Arguments
 
-| Format          | TypeScript Type                                             | Example                                               |
-| --------------- | ----------------------------------------------------------- | ----------------------------------------------------- |
-| `string`        | `string \| number \| boolean`                               | `{name}`                                              |
-| `number`        | ``number \| `${number}`  ``                                 | `{count, number, ...}`                                |
-| `date`          | ``Date \| number \| `${number}`  ``                         | `{date, date, short}`                                 |
-| `time`          | ``Date \| number \| `${number}`  ``                         | `{time, time, medium}`                                |
-| `plural`        | ``number \| `${number}`  ``                                 | `{count, plural, one {...} other {...}}`              |
-| `selectordinal` | ``number \| `${number}`  ``                                 | `{position, selectordinal, one {#st} other {#th}}`    |
-| `select`        | `union \| string \| number \| boolean \| null \| undefined` | `{theme, select, light {...} dark {...} other {...}}` |
+| Format          | TypeScript Type                                 | Example                                               |
+| --------------- | ----------------------------------------------- | ----------------------------------------------------- |
+| `string`        | `string \| number \| boolean`                   | `{name}`                                              |
+| `number`        | ``number \| `${number}`  ``                     | `{count, number, ...}`                                |
+| `date`          | ``Date \| number \| `${number}`  ``             | `{date, date, short}`                                 |
+| `time`          | ``Date \| number \| `${number}`  ``             | `{time, time, medium}`                                |
+| `plural`        | ``number \| `${number}`  ``                     | `{count, plural, one {...} other {...}}`              |
+| `selectordinal` | ``number \| `${number}`  ``                     | `{position, selectordinal, one {#st} other {#th}}`    |
+| `select`        | `union \| string \| number \| boolean \| null ` | `{theme, select, light {...} dark {...} other {...}}` |
 
 #### Additional Features
 
 - **Enhanced Value Types**: Non-formatted arguments accept `string | number | boolean` for more flexible usage
 - **String Number Support**: Numeric formats accept both `number` and template literal `\`${number}\`` types
-- **Comprehensive Select Matching**: Select arguments with `other` clauses support `string`, `number`, `boolean`, `null`, and `undefined`
+- **Comprehensive Select Matching**: Select arguments with `other` clauses support `string`, `number`, `boolean`, and `null`
 - **Literal Type Transformation**: Select keys are intelligently transformed (e.g., `'123'` becomes `'123' | 123`, `'true'` becomes `'true' | true`)
 - **Escaped content**: Properly handles quoted/escaped text that shouldn't be parsed as arguments
 - **Nested messages**: Supports complex nested structures
@@ -113,7 +113,7 @@ type SelectArg = ICUMessageArguments<`{theme, select,
   dark {The interface will be dark}
   other {The interface will use default colors}
 }`>;
-// Result: { theme: 'light' | 'dark' | ({} & string) | ({} & number) | boolean | undefined | null }
+// Result: { theme: 'light' | 'dark' | ({} & string) | ({} & number) | boolean | null }
 
 type SelectWithoutOther = ICUMessageArguments<`{status, select,
   active {Currently active}
@@ -168,7 +168,7 @@ type NestedArgs = ICUMessageArguments<`{theme, select,
     }
   }
 }`>;
-// Result: { theme: 'dark' | 'light' | ({} & string) | ({} & number) | boolean | undefined | null; count: number | `${number}` }
+// Result: { theme: 'dark' | 'light' | ({} & string) | ({} & number) | boolean | null; count: number | `${number}` }
 ```
 
 ### `ICUMessageTags<T>`

--- a/README.md
+++ b/README.md
@@ -53,18 +53,18 @@ Extracts the argument types from an ICU message string.
 | Format          | TypeScript Type                                             | Example                                               |
 | --------------- | ----------------------------------------------------------- | ----------------------------------------------------- |
 | `string`        | `string \| number \| boolean`                               | `{name}`                                              |
-| `number`        | `number \| \`${number}\``                                   | `{count, number, ...}`                                |
-| `date`          | `Date \| number \| \`${number}\``                           | `{date, date, short}`                                 |
-| `time`          | `Date \| number \| \`${number}\``                           | `{time, time, medium}`                                |
-| `plural`        | `number \| \`${number}\``                                   | `{count, plural, one {...} other {...}}`              |
-| `selectordinal` | `number \| \`${number}\``                                   | `{position, selectordinal, one {#st} other {#th}}`    |
+| `number`        | ``number \| `${number}`  ``                                 | `{count, number, ...}`                                |
+| `date`          | ``Date \| number \| `${number}`  ``                         | `{date, date, short}`                                 |
+| `time`          | ``Date \| number \| `${number}`  ``                         | `{time, time, medium}`                                |
+| `plural`        | ``number \| `${number}`  ``                                 | `{count, plural, one {...} other {...}}`              |
+| `selectordinal` | ``number \| `${number}`  ``                                 | `{position, selectordinal, one {#st} other {#th}}`    |
 | `select`        | `union \| string \| number \| boolean \| null \| undefined` | `{theme, select, light {...} dark {...} other {...}}` |
 
 #### Additional Features
 
 - **Enhanced Value Types**: Non-formatted arguments accept `string | number | boolean` for more flexible usage
 - **String Number Support**: Numeric formats accept both `number` and template literal `\`${number}\`` types
-- **Comprehensive Select Matching**: Select arguments with `other` clauses support strings, numbers, booleans, null, and undefined
+- **Comprehensive Select Matching**: Select arguments with `other` clauses support `string`, `number`, `boolean`, `null`, and `undefined`
 - **Literal Type Transformation**: Select keys are intelligently transformed (e.g., `'123'` becomes `'123' | 123`, `'true'` becomes `'true' | true`)
 - **Escaped content**: Properly handles quoted/escaped text that shouldn't be parsed as arguments
 - **Nested messages**: Supports complex nested structures

--- a/README.md
+++ b/README.md
@@ -28,14 +28,14 @@ import type { ICUMessageArguments, ICUMessageTags } from 'icu-message-types';
 
 // Extract argument types
 type Args0 = ICUMessageArguments<'Hello, {firstName} {lastName}!'>;
-// Result: { firstName: string; lastName: string }
+// Result: { firstName: string | number | boolean; lastName: string | number | boolean }
 
 type Args1 = ICUMessageArguments<`{theme, select,
   light {The interface will be bright}
   dark {The interface will be dark}
   other {The interface will use default colors}
 }`>;
-// Result: { theme: 'light' | 'dark' | (string & {}) }
+// Result: { theme: 'light' | 'dark' | ({} & string) | ({} & number) | boolean | undefined | null }
 
 // Extract tag names
 type Tags = ICUMessageTags<'Click <link>here</link> to continue'>;
@@ -50,18 +50,22 @@ Extracts the argument types from an ICU message string.
 
 #### Message Arguments
 
-| Format          | TypeScript Type   | Example                                               |
-| --------------- | ----------------- | ----------------------------------------------------- |
-| `string`        | `string`          | `{name}`                                              |
-| `number`        | `number`          | `{count, number, ...}`                                |
-| `date`          | `Date \| number`  | `{date, date, short}`                                 |
-| `time`          | `Date \| number`  | `{time, time, medium}`                                |
-| `plural`        | `number`          | `{count, plural, one {...} other {...}}`              |
-| `selectordinal` | `number`          | `{position, selectordinal, one {#st} other {#th}}`    |
-| `select`        | `union \| string` | `{theme, select, light {...} dark {...} other {...}}` |
+| Format          | TypeScript Type                                             | Example                                               |
+| --------------- | ----------------------------------------------------------- | ----------------------------------------------------- |
+| `string`        | `string \| number \| boolean`                               | `{name}`                                              |
+| `number`        | `number \| \`${number}\``                                   | `{count, number, ...}`                                |
+| `date`          | `Date \| number \| \`${number}\``                           | `{date, date, short}`                                 |
+| `time`          | `Date \| number \| \`${number}\``                           | `{time, time, medium}`                                |
+| `plural`        | `number \| \`${number}\``                                   | `{count, plural, one {...} other {...}}`              |
+| `selectordinal` | `number \| \`${number}\``                                   | `{position, selectordinal, one {#st} other {#th}}`    |
+| `select`        | `union \| string \| number \| boolean \| null \| undefined` | `{theme, select, light {...} dark {...} other {...}}` |
 
 #### Additional Features
 
+- **Enhanced Value Types**: Non-formatted arguments accept `string | number | boolean` for more flexible usage
+- **String Number Support**: Numeric formats accept both `number` and template literal `\`${number}\`` types
+- **Comprehensive Select Matching**: Select arguments with `other` clauses support strings, numbers, booleans, null, and undefined
+- **Literal Type Transformation**: Select keys are intelligently transformed (e.g., `'123'` becomes `'123' | 123`, `'true'` becomes `'true' | true`)
 - **Escaped content**: Properly handles quoted/escaped text that shouldn't be parsed as arguments
 - **Nested messages**: Supports complex nested structures
 - **Whitespace handling**: Automatically strips whitespace and new lines for improved parsing
@@ -70,35 +74,35 @@ Extracts the argument types from an ICU message string.
 
 ```typescript
 type Args = ICUMessageArguments<'Hello, {name}!'>;
-// Result: { name: string }
+// Result: { name: string | number | boolean }
 
 type MultipleArgs = ICUMessageArguments<'Hello, {firstName} {lastName}!'>;
-// Result: { firstName: string; lastName: string }
+// Result: { firstName: string | number | boolean; lastName: string | number | boolean }
 ```
 
 #### Number Arguments
 
 ```typescript
 type NumberArg = ICUMessageArguments<'I have {count, number} cats'>;
-// Result: { count: number }
+// Result: { count: number | `${number}` }
 
 type CurrencyArg =
   ICUMessageArguments<'Price: {price, number, ::currency/USD}'>;
-// Result: { price: number }
+// Result: { price: number | `${number}` }
 
 type PercentArg =
   ICUMessageArguments<'Progress: {progress, number, ::percent}'>;
-// Result: { progress: number }
+// Result: { progress: number | `${number}` }
 ```
 
 #### Date and Time Arguments
 
 ```typescript
 type DateArg = ICUMessageArguments<'Event date: {date, date, medium}'>;
-// Result: { date: Date | number }
+// Result: { date: Date | number | `${number}` }
 
 type TimeArg = ICUMessageArguments<'Meeting at {time, time, short}'>;
-// Result: { time: Date | number }
+// Result: { time: Date | number | `${number}` }
 ```
 
 #### Select Arguments
@@ -109,7 +113,7 @@ type SelectArg = ICUMessageArguments<`{theme, select,
   dark {The interface will be dark}
   other {The interface will use default colors}
 }`>;
-// Result: { theme: 'light' | 'dark' | (string & {}) }
+// Result: { theme: 'light' | 'dark' | ({} & string) | ({} & number) | boolean | undefined | null }
 
 type SelectWithoutOther = ICUMessageArguments<`{status, select,
   active {Currently active}
@@ -126,7 +130,7 @@ type PluralArg = ICUMessageArguments<`{count, plural,
   one {One item}
   other {# items}
 }`>;
-// Result: { count: number }
+// Result: { count: number | `${number}` }
 ```
 
 #### Selectordinal Arguments
@@ -138,7 +142,7 @@ type OrdinalArg = ICUMessageArguments<`{position, selectordinal,
   few {#rd place}
   other {#th place}
 }`>;
-// Result: { position: number }
+// Result: { position: number | `${number}` }
 ```
 
 #### Nested Arguments
@@ -164,7 +168,7 @@ type NestedArgs = ICUMessageArguments<`{theme, select,
     }
   }
 }`>;
-// Result: { theme: 'dark' | 'light' | (string & {}); count: number }
+// Result: { theme: 'dark' | 'light' | ({} & string) | ({} & number) | boolean | undefined | null; count: number | `${number}` }
 ```
 
 ### `ICUMessageTags<T>`

--- a/src/message-arguments.d.ts
+++ b/src/message-arguments.d.ts
@@ -22,13 +22,18 @@ type Value<T extends MessageArgumentFormat> = T extends
   : T extends 'date' | 'time'
     ? Date | number | `${number}`
     : T extends 'select'
-      ? string | number | boolean | null | undefined
+      ? string | number | boolean | null
       : never;
 
 /**
  * Value type for non-formatted arguments (e.g. `{firstName}`)
  */
-type NonFormattedValue = string | number | boolean;
+type UnformattedValue = string | number | boolean;
+
+/**
+ * Value type for Select's "other" matcher argument
+ */
+type SelectOtherValue = ({} & string) | ({} & number) | boolean | null;
 
 /**
  * Message argument tuple with the key and value.
@@ -80,7 +85,7 @@ type ExtractSimpleArgument<S extends string> = S extends
   ? Format extends MessageArgumentFormat
     ? MessageArgument<Name, Value<Format>>
     : never
-  : MessageArgument<S, NonFormattedValue>;
+  : MessageArgument<S, UnformattedValue>;
 
 /**
  * Handle complex type argument extraction (i.e plural, select, and selectordinal) which
@@ -137,7 +142,7 @@ type ExtractSelectMatches<
  * - `'1234'`: `'1234' | 1234`
  */
 type TransformSelectMatches<S extends string> = S extends 'other'
-  ? ({} & string) | ({} & number) | boolean | undefined | null
+  ? SelectOtherValue
   : S extends `${infer P extends boolean | number}`
     ? S | P
     : S;

--- a/src/message-arguments.d.ts
+++ b/src/message-arguments.d.ts
@@ -18,20 +18,22 @@ type Value<T extends MessageArgumentFormat> = T extends
   | 'number'
   | 'plural'
   | 'selectordinal'
-  ? number
+  ? number | `${number}`
   : T extends 'date' | 'time'
-    ? Date | number
+    ? Date | number | `${number}`
     : T extends 'select'
-      ? string
+      ? string | number | boolean | null | undefined
       : never;
+
+/**
+ * Value type for non-formatted arguments (e.g. `{firstName}`)
+ */
+type NonFormattedValue = string | number | boolean;
 
 /**
  * Message argument tuple with the key and value.
  */
-type MessageArgument<
-  K extends string,
-  V extends Value<MessageArgumentFormat>,
-> = K extends '' ? never : [K, V];
+type MessageArgument<K extends string, V> = K extends '' ? never : [K, V];
 
 /**
  * Utility type to remove escaped characters.
@@ -78,7 +80,7 @@ type ExtractSimpleArgument<S extends string> = S extends
   ? Format extends MessageArgumentFormat
     ? MessageArgument<Name, Value<Format>>
     : never
-  : MessageArgument<S, string>;
+  : MessageArgument<S, NonFormattedValue>;
 
 /**
  * Handle complex type argument extraction (i.e plural, select, and selectordinal) which
@@ -93,7 +95,7 @@ type ExtractComplexArgument<S extends string> =
           ?
               | MessageArgument<
                   Name,
-                  ReplaceOtherArgument<ExtractSelectMatches<Rest>>
+                  TransformSelectMatches<ExtractSelectMatches<Rest>>
                 >
               | ExtractNestedArguments<Rest>
           : never
@@ -128,11 +130,17 @@ type ExtractSelectMatches<
     Result | (S extends '' ? never : S);
 
 /**
- * Replace "other" with any string
+ * Transform select matches
+ * - `'other'`: any string, any number, boolean, undefined, or null
+ * - `'true'`: `'true' | true`
+ * - `'false'`: `'false' | false`
+ * - `'1234'`: `'1234' | 1234`
  */
-type ReplaceOtherArgument<S extends string> = S extends 'other'
-  ? {} & string
-  : S;
+type TransformSelectMatches<S extends string> = S extends 'other'
+  ? ({} & string) | ({} & number) | boolean | undefined | null
+  : S extends `${infer P extends boolean | number}`
+    ? S | P
+    : S;
 
 /**
  * Replaces an empty object with `never`.

--- a/src/utils.d.ts
+++ b/src/utils.d.ts
@@ -10,11 +10,6 @@ export type Replace<
   : S;
 
 /**
- * Pop the first item out of an array
- */
-export type Pop<T extends any[]> = T extends [...infer R, any] ? R : [];
-
-/**
  * Utility type to remove all spaces, new lines, and tabs from the provided string.
  */
 export type StripWhitespace<S extends string> = Replace<
@@ -22,6 +17,11 @@ export type StripWhitespace<S extends string> = Replace<
   ' ',
   ''
 >;
+
+/**
+ * Pop the first item out of an array
+ */
+export type Pop<T extends any[]> = T extends [...infer R, any] ? R : [];
 
 /**
  * Consume characters until the matching closing brace for an already-seen "{"

--- a/tests/ICUMessageArguments.test-d.ts
+++ b/tests/ICUMessageArguments.test-d.ts
@@ -1,48 +1,53 @@
 import { expectTypeOf, test } from 'vitest';
 import type { ICUMessageArguments } from '../src/message-arguments';
 
+type Other = ({} & string) | ({} & number) | boolean | undefined | null;
+
 test('{string}', () => {
   expectTypeOf<ICUMessageArguments<`hello {name}`>>().toEqualTypeOf<{
-    name: string;
+    name: string | number | boolean;
   }>();
 
   expectTypeOf<
     ICUMessageArguments<`hello {firstName} {lastName}`>
-  >().toEqualTypeOf<{ firstName: string; lastName: string }>();
+  >().toEqualTypeOf<{
+    firstName: string | number | boolean;
+    lastName: string | number | boolean;
+  }>();
 });
 
 test('{number}', () => {
   expectTypeOf<
     ICUMessageArguments<`I have {num, number} cats.`>
-  >().toEqualTypeOf<{ num: number }>();
+  >().toEqualTypeOf<{ num: number | `${number}` }>();
 
   expectTypeOf<
     ICUMessageArguments<`The price of this bagel is {num, number, ::sign-always compact-short currency/GBP}`>
-  >().toEqualTypeOf<{ num: number }>();
+  >().toEqualTypeOf<{ num: number | `${number}` }>();
 
   expectTypeOf<
     ICUMessageArguments<`Almost {num, number, ::percent} of them are green.`>
-  >().toEqualTypeOf<{ num: number }>();
+  >().toEqualTypeOf<{ num: number | `${number}` }>();
 
   expectTypeOf<
     ICUMessageArguments<`The duration is {num, number, ::.##} seconds`>
-  >().toEqualTypeOf<{ num: number }>();
+  >().toEqualTypeOf<{ num: number | `${number}` }>();
 
   expectTypeOf<
     ICUMessageArguments<`The very precise number is {num, number, ::.00}`>
-  >().toEqualTypeOf<{ num: number }>();
+  >().toEqualTypeOf<{ num: number | `${number}` }>();
 });
 
 test('{date}', () => {
   expectTypeOf<
     ICUMessageArguments<`Sale begins {start, date, medium}`>
-  >().toEqualTypeOf<{ start: Date | number }>();
+  >().toEqualTypeOf<{ start: Date | number | `${number}` }>();
 });
 
 test('{time}', () => {
   expectTypeOf<
     ICUMessageArguments<`Coupon expires at {expire, time, short}`>
-  >().toEqualTypeOf<{ expire: Date | number }>();
+  >().toEqualTypeOf<{ expire: Date | number | `${number}` }>();
 });
 
 test('{select}', () => {
@@ -52,7 +57,9 @@ test('{select}', () => {
       dark {The interface will be dark.}
       other {The interface will use default colors.}
     }`>
-  >().toEqualTypeOf<{ theme: 'light' | 'dark' | (string & {}) }>();
+  >().toEqualTypeOf<{
+    theme: 'light' | 'dark' | Other;
+  }>();
 
   expectTypeOf<
     ICUMessageArguments<`{theme, select,
@@ -67,26 +74,30 @@ test('{select}', () => {
       other {No taxes apply.}
     }`>
   >().toEqualTypeOf<{
-    isTaxed: 'yes' | (string & {});
-    tax: number;
-    person: string;
+    isTaxed: 'yes' | ({} & string) | ({} & number) | boolean | undefined | null;
+    tax: number | `${number}`;
+    person: string | number | boolean;
   }>();
 
   // Select with only "other"
   expectTypeOf<
     ICUMessageArguments<`{choice, select, other {Only other option}}`>
-  >().toEqualTypeOf<{ choice: {} & string }>();
+  >().toEqualTypeOf<{
+    choice: ({} & string) | ({} & number) | boolean | undefined | null;
+  }>();
 
   // Select with numeric-looking keys
   expectTypeOf<
     ICUMessageArguments<`{num, select, 123 {Numeric key} other {Other}}`>
-  >().toEqualTypeOf<{ num: '123' | ({} & string) }>();
+  >().toEqualTypeOf<{
+    num: '123' | 123 | Other;
+  }>();
 
   // Select with special character keys
   expectTypeOf<
     ICUMessageArguments<`{special, select, key-with-dashes {Dashed} key_with_underscores {Underscored} other {Other}}`>
   >().toEqualTypeOf<{
-    special: 'key-with-dashes' | 'key_with_underscores' | ({} & string);
+    special: 'key-with-dashes' | 'key_with_underscores' | Other;
   }>();
 });
 
@@ -96,7 +107,7 @@ test('{plural}', () => {
       one {Cart: {itemCount, number} item}
       other {Cart: {itemCount, number} items}
     }`>
-  >().toEqualTypeOf<{ itemCount: number }>();
+  >().toEqualTypeOf<{ itemCount: number | `${number}` }>();
 
   expectTypeOf<
     ICUMessageArguments<`{itemCount, plural,
@@ -104,7 +115,7 @@ test('{plural}', () => {
       one {You have {itemCount, number} item.}
       other {You have {itemCount, number} items.}
     }`>
-  >().toEqualTypeOf<{ itemCount: number }>();
+  >().toEqualTypeOf<{ itemCount: number | `${number}` }>();
 
   expectTypeOf<
     ICUMessageArguments<`{itemCount, plural,
@@ -112,7 +123,7 @@ test('{plural}', () => {
       one {You have # item.}
       other {You have # items.}
     }`>
-  >().toEqualTypeOf<{ itemCount: number }>();
+  >().toEqualTypeOf<{ itemCount: number | `${number}` }>();
 });
 
 test('{selectordinal}', () => {
@@ -123,7 +134,7 @@ test('{selectordinal}', () => {
       few {#rd}
       other {#th}
     } birthday!`>
-  >().toEqualTypeOf<{ year: number }>();
+  >().toEqualTypeOf<{ year: number | `${number}` }>();
 });
 
 test('No Arguments', () => {
@@ -151,14 +162,17 @@ test('Malformed Inputs', () => {
 test('Unknown Format', () => {
   expectTypeOf<
     ICUMessageArguments<`hello {firstName, foo} {middleName} {lastName, bar}`>
-  >().toEqualTypeOf<{ middleName: string }>();
+  >().toEqualTypeOf<{ middleName: string | number | boolean }>();
 });
 
 test('Rich Text Formatting', () => {
   expectTypeOf<
     ICUMessageArguments<`Our price is <boldThis>{price, number, ::currency/USD precision-integer}</boldThis>
 with <link>{pct, number, ::percent} discount</link>`>
-  >().toEqualTypeOf<{ price: number; pct: number }>();
+  >().toEqualTypeOf<{
+    price: number | `${number}`;
+    pct: number | `${number}`;
+  }>();
 });
 
 test('Quoting / Escaping', () => {
@@ -182,17 +196,20 @@ test('Quoting / Escaping', () => {
 
   expectTypeOf<
     ICUMessageArguments<`These are not interpolations: '{word1} {word2}', but these are {word3} {word4}`>
-  >().toEqualTypeOf<{ word3: string; word4: string }>();
+  >().toEqualTypeOf<{
+    word3: string | number | boolean;
+    word4: string | number | boolean;
+  }>();
 
   // Multiple consecutive quotes
   expectTypeOf<
     ICUMessageArguments<`This ''isn''''t'' obvious with {name}.`>
-  >().toEqualTypeOf<{ name: string }>();
+  >().toEqualTypeOf<{ name: string | number | boolean }>();
 
   // Mixed quoted and unquoted content
   expectTypeOf<
     ICUMessageArguments<`Start '{not_arg}' middle {real_arg} end '{not_arg2}'`>
-  >().toEqualTypeOf<{ real_arg: string }>();
+  >().toEqualTypeOf<{ real_arg: string | number | boolean }>();
 
   // Quotes around entire message
   expectTypeOf<
@@ -222,8 +239,8 @@ test('Nested Complex Arguments', () => {
       }}
     }`>
   >().toEqualTypeOf<{
-    theme: ({} & string) | 'dark' | 'light';
-    num_items: ({} & string) | 'one';
+    theme: Other | 'dark' | 'light';
+    num_items: Other | 'one';
   }>();
 
   expectTypeOf<
@@ -251,10 +268,10 @@ test('Nested Complex Arguments', () => {
         }
   }`>
   >().toEqualTypeOf<{
-    role_of_host: ({} & string) | 'organizer' | 'participant';
-    num_guests: number;
-    host: string;
-    guest: string;
+    role_of_host: Other | 'organizer' | 'participant';
+    num_guests: number | `${number}`;
+    host: string | number | boolean;
+    guest: string | number | boolean;
   }>();
 
   expectTypeOf<
@@ -286,10 +303,109 @@ test('Nested Complex Arguments', () => {
           other {{host} invites {guest} and # other people to attend.}}}
     }`>
   >().toEqualTypeOf<{
-    role_of_host: ({} & string) | 'organizer' | 'participant';
-    num_guests: number;
-    host: string;
-    guest: string;
-    year: number;
+    role_of_host: Other | 'organizer' | 'participant';
+    num_guests: number | `${number}`;
+    host: string | number | boolean;
+    guest: string | number | boolean;
+    year: number | `${number}`;
+  }>();
+});
+
+test('Enhanced Select Transformations', () => {
+  // Test boolean literal transformations
+  expectTypeOf<
+    ICUMessageArguments<`{isActive, select, true {Active} false {Inactive} other {Unknown}}`>
+  >().toEqualTypeOf<{
+    isActive: 'true' | true | 'false' | false | Other;
+  }>();
+
+  // Test number literal transformations
+  expectTypeOf<
+    ICUMessageArguments<`{status, select, 0 {Zero} 1 {One} 42 {Forty-two} other {Other number}}`>
+  >().toEqualTypeOf<{
+    status: '0' | 0 | '1' | 1 | '42' | 42 | Other;
+  }>();
+
+  // Test decimal number transformations
+  expectTypeOf<
+    ICUMessageArguments<`{score, select, 3.14 {Pi} 2.71 {E} other {Other}}`>
+  >().toEqualTypeOf<{
+    score: '3.14' | 3.14 | '2.71' | 2.71 | Other;
+  }>();
+
+  // Test negative number transformations
+  expectTypeOf<
+    ICUMessageArguments<`{temp, select, -10 {Cold} 0 {Freezing} other {Other}}`>
+  >().toEqualTypeOf<{
+    temp: '-10' | -10 | '0' | 0 | Other;
+  }>();
+
+  // Test mixed literal types without 'other'
+  expectTypeOf<
+    ICUMessageArguments<`{mixed, select, true {Boolean} 123 {Number} regular {String}}`>
+  >().toEqualTypeOf<{
+    mixed: 'true' | true | '123' | 123 | 'regular';
+  }>();
+
+  // Test select with only boolean literals
+  expectTypeOf<
+    ICUMessageArguments<`{toggle, select, true {On} false {Off}}`>
+  >().toEqualTypeOf<{
+    toggle: 'true' | true | 'false' | false;
+  }>();
+
+  // Test select with comprehensive type coverage
+  expectTypeOf<
+    ICUMessageArguments<`{value, select,
+      true {Boolean true}
+      false {Boolean false}
+      0 {Number zero}
+      1 {Number one}
+      -5 {Negative number}
+      3.14 {Decimal}
+      someString {Regular string}
+      other {Fallback for any other value}
+    }`>
+  >().toEqualTypeOf<{
+    value:
+      | 'true'
+      | true
+      | 'false'
+      | false
+      | '0'
+      | 0
+      | '1'
+      | 1
+      | '-5'
+      | -5
+      | '3.14'
+      | 3.14
+      | 'someString'
+      | Other;
+  }>();
+
+  // Test select without 'other' but with mixed types
+  expectTypeOf<
+    ICUMessageArguments<`{status, select,
+      true {Success}
+      false {Failure}
+      1 {Pending}
+      0 {Inactive}
+      loading {Loading}
+    }`>
+  >().toEqualTypeOf<{
+    status: 'true' | true | 'false' | false | '1' | 1 | '0' | 0 | 'loading';
+  }>();
+
+  // Test nested select with literal transformations
+  expectTypeOf<
+    ICUMessageArguments<`{outer, select,
+      true {Inner: {inner, select, 1 {One} 2 {Two} other {Other}}}
+      false {Inner: {inner, select, on {On} off {Off}}}
+      other {No inner}
+    }`>
+  >().toEqualTypeOf<{
+    outer: 'true' | true | 'false' | false | Other;
+    inner: '1' | 1 | '2' | 2 | 'on' | 'off' | Other;
   }>();
 });


### PR DESCRIPTION
**Enhanced Value Types**
- **Non-formatted arguments** now accept `string | number | boolean` (previously just `string`)
- **Numeric formats** now support both `number` and template literal `` `${number}` `` types
- **Date/time formats** expanded to `` Date | number | `${number}` ``

**Improved Select Argument Handling**
- **Smart literal transformation**: `'123'` → `'123' | 123`, `'true'` → `'true' | true`
- **Comprehensive `other` support**: Now includes `({} & string) | ({} & number) | boolean | null`
